### PR TITLE
Add Auto Formatting Action for Master Branch

### DIFF
--- a/.github/workflows/auto-formatting.yml
+++ b/.github/workflows/auto-formatting.yml
@@ -1,0 +1,30 @@
+name: Formatting code
+on:
+  push:
+    branches:
+      - master
+jobs:
+  auto_format:
+    # Check if the PR is not from a fork
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fix Python Formatting
+        id: autopep8
+        uses: peter-evans/autopep8@v1
+        with:
+          args: --exit-code --recursive --in-place --aggressive .
+      - name: Fix Javascript Formatting
+        run: npx prettier --write src/**.js
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+      - name: Push changes
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'waterlooairlock'
+          git config --global user.email 'Watlockemail@gmail.com'
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -am "Automated Formatting Fixes"
+          git push


### PR DESCRIPTION
This action serves to automatically commit formatting changes after any commit is added to the master branch (unless there are no changes to be made).

This includes Merged Pull requests and direct commits to the Master branch (which their shouldnt be in most cases).

While I am farely confident this will work, Nothing is for sure.\
So there may be some troubleshooting involved.